### PR TITLE
Small build.gradle changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '0.5-SNAPSHOT'
+    id 'fabric-loom' version '0.6-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -21,9 +21,9 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
     // Fabric API
-    modCompile(fabricApi.module("fabric-renderer-api-v1", project.fabric_version))
-    modCompile(fabricApi.module("fabric-rendering-data-attachment-v1", project.fabric_version))
-    modCompile(fabricApi.module("fabric-rendering-fluids-v1", project.fabric_version))
+    modImplementation(fabricApi.module("fabric-renderer-api-v1", project.fabric_version))
+    modImplementation(fabricApi.module("fabric-rendering-data-attachment-v1", project.fabric_version))
+    modImplementation(fabricApi.module("fabric-rendering-fluids-v1", project.fabric_version))
 
     // For testing in dev environment
     modRuntime "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"


### PR DESCRIPTION
- Bump loom version to 0.6-SNAPSHOT so that the mod builds on JDK 16
- Change deprecated `modCompile` to `modImplementation` so that the mod builds on JDK 16

Technically, building on JDK 16 also requires Gradle 7 release candidates, but that can be done locally on the computer (by installing gradle and using `gradle build` rather than `gradlew build` to use local gradle rather than the gradle wrapper), whereas these changes are required in the mod's source code.

I would've included a gradle bump as well if it was fully released (rather than release candidate).