### PR TITLE
Remove redundant `chmod +x gradlew`

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -12,8 +12,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 8
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
     - name: Upload build artifacts


### PR DESCRIPTION
This has been useless since #12 was merged.