### PR TITLE
Fix build for gradle 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,13 +37,8 @@ dependencies {
 processResources {
     inputs.property "version", project.version
 
-    from(sourceSets.main.resources.srcDirs) {
-        include "fabric.mod.json"
+    filesMatching("fabric.mod.json") {
         expand "version": project.version
-    }
-
-    from(sourceSets.main.resources.srcDirs) {
-        exclude "fabric.mod.json"
     }
 }
 


### PR DESCRIPTION
Old method of expanding `fabric.mod.json`'s `project.version` property broke with gradle 7. Switching to using `filesMatching("fabric.mod.json")` fixes this.