### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Indium
-Adaptation of Indigo (Reference implementation of the Fabric Rendering API) for use with Sodium. Currently requires bleeding-edge builds of the Sodium [1.16.x/next branch](https://github.com/CaffeineMC/sodium-fabric#bleeding-edge-builds-unstable). (my fork is no longer necessary)
+Adaptation of Indigo (Reference implementation of the Fabric Rendering API) for use with Sodium. Requires [Sodium 0.2.0](https://github.com/CaffeineMC/sodium-fabric/releases/tag/mc1.16.5-0.2.0) or later. (my fork is no longer necessary)
 
 Based heavily upon [Indigo](https://github.com/FabricMC/fabric/tree/1.16/fabric-renderer-indigo) (licensed Apache 2.0)


### PR DESCRIPTION
This file should be updated saying that Indium requires Sodium 0.2.0 or above instead of the bleeding edge builds.

first PR btw tell me if I do something wrong