### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Indium
-Adaptation of Indigo (Reference implementation of the Fabric Rendering API) for use with Sodium. Currently requires bleeding-edge builds of the Sodium [1.16.x/next branch](https://github.com/CaffeineMC/sodium-fabric#bleeding-edge-builds-unstable). (my fork is no longer necessary)
+Adaptation of Indigo (Reference implementation of the Fabric Rendering API) for use with Sodium.
 
-Based heavily upon [Indigo](https://github.com/FabricMC/fabric/tree/1.16/fabric-renderer-indigo) (licensed Apache 2.0)
+Based heavily upon [Indigo](https://github.com/FabricMC/fabric/tree/1.17/fabric-renderer-indigo) (licensed Apache 2.0)
+  


### PR DESCRIPTION
Another update, this time to 1.17.x/main with a README.md file for the branch. Sodium requirement removed as everyone should be on 0.3 or above.