### PR TITLE
Update for 1.18 RC3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,8 +5,8 @@ plugins {
 	id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
-sourceCompatibility = JavaVersion.VERSION_16
-targetCompatibility = JavaVersion.VERSION_16
+sourceCompatibility = JavaVersion.VERSION_17
+targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = project.archives_base_name
 if (grgit != null) {
@@ -48,12 +48,12 @@ dependencies {
 		// Jitpack doesn't work with Gradle 7, so this is the easiest solution
 		implementation("me.jellysquid.mods:sodium-fabric") {
 			version {
-				branch = "1.17.x/dev"
+				branch = "1.18.x/dev"
 			}
 			transitive = false
 		}
 	} else {
-		modImplementation "maven.modrinth:sodium:mc1.17.1-0.3.3"
+		modImplementation "maven.modrinth:sodium:mc1.18-pre8-0.4.0alpha4"
 	}
 
 	// Transitive dependency of Sodium
@@ -76,7 +76,7 @@ tasks.withType(JavaCompile).configureEach {
 	it.options.encoding = "UTF-8"
 
 	// Minecraft 1.17 (21w19a) upwards uses Java 16.
-	it.options.release = 16
+	it.options.release = 17
 }
 
 java {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,13 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.17.1
-yarn_mappings=1.17.1+build.1
-loader_version=0.11.6
+minecraft_version=1.18-rc3
+yarn_mappings=1.18-rc3+build.1
+loader_version=0.12.5
 # Mod Properties
 mod_version=1.0.1
 maven_group=link.infra
 archives_base_name=indium
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.36.1+1.17
+fabric_version=0.41.1+1.18

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/link/infra/indium/mixin/renderer/MixinItemRenderer.java
+++ b/src/main/java/link/infra/indium/mixin/renderer/MixinItemRenderer.java
@@ -43,11 +43,11 @@ public abstract class MixinItemRenderer implements AccessItemRenderer {
 	protected abstract void renderBakedItemModel(BakedModel model, ItemStack stack, int light, int overlay, MatrixStack matrixStack, VertexConsumer buffer);
 
 	@Shadow
-	protected ItemColors colorMap;
+	protected ItemColors colors;
 
 	private final VanillaQuadHandler vanillaHandler = new IndigoQuadHandler(this);
 
-	private final ThreadLocal<ItemRenderContext> CONTEXTS = ThreadLocal.withInitial(() -> new ItemRenderContext(colorMap));
+	private final ThreadLocal<ItemRenderContext> CONTEXTS = ThreadLocal.withInitial(() -> new ItemRenderContext(colors));
 
     @Inject(at = @At("HEAD"), method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation$Mode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", cancellable = true)
 	public void hook_method_23179(ItemStack stack, ModelTransformation.Mode transformMode, boolean invert, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, int overlay, BakedModel model, CallbackInfo ci) {

--- a/src/main/java/link/infra/indium/renderer/render/BlockRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/BlockRenderContext.java
@@ -98,8 +98,8 @@ public class BlockRenderContext extends AbstractRenderContext implements RenderC
 
 	public boolean render(BlockRenderView blockView, BakedModel model, BlockState state, BlockPos pos, MatrixStack matrixStack, VertexConsumer buffer, Random random, long seed, int overlay) {
 		this.bufferBuilder = buffer;
-		this.matrix = matrixStack.peek().getModel();
-		this.normalMatrix = matrixStack.peek().getNormal();
+		this.matrix = matrixStack.peek().getPositionMatrix();
+		this.normalMatrix = matrixStack.peek().getNormalMatrix();
 		this.random = random;
 		this.seed = seed;
 

--- a/src/main/java/link/infra/indium/renderer/render/IndiumTerrainRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/IndiumTerrainRenderContext.java
@@ -70,8 +70,8 @@ public class IndiumTerrainRenderContext extends AbstractRenderContext implements
 
     /** Called from chunk renderer hook. */
     public boolean tesselateBlock(BlockState blockState, BlockPos blockPos, BlockPos origin, final BakedModel model, MatrixStack matrixStack) {
-        this.matrix = matrixStack.peek().getModel();
-        this.normalMatrix = matrixStack.peek().getNormal();
+        this.matrix = matrixStack.peek().getPositionMatrix();
+        this.normalMatrix = matrixStack.peek().getNormalMatrix();
 
         try {
             aoCalc.clear();

--- a/src/main/java/link/infra/indium/renderer/render/ItemRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/ItemRenderContext.java
@@ -106,8 +106,8 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 		matrixStack.push();
 		((BakedModel) model).getTransformation().getTransformation(transformMode).apply(invert, matrixStack);
 		matrixStack.translate(-0.5D, -0.5D, -0.5D);
-		matrix = matrixStack.peek().getModel();
-		normalMatrix = matrixStack.peek().getNormal();
+		matrix = matrixStack.peek().getPositionMatrix();
+		normalMatrix = matrixStack.peek().getNormalMatrix();
 
 		model.emitItemQuads(itemStack, randomSupplier, this);
 
@@ -163,7 +163,7 @@ public class ItemRenderContext extends AbstractRenderContext implements RenderCo
 
 	private int indexColor() {
 		final int colorIndex = editorQuad.colorIndex();
-		return colorIndex == -1 ? -1 : (colorMap.getColorMultiplier(itemStack, colorIndex) | 0xFF000000);
+		return colorIndex == -1 ? -1 : (colorMap.getColor(itemStack, colorIndex) | 0xFF000000);
 	}
 
 	private void renderQuad() {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,8 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.8.0",
-		"minecraft": "1.17.x",
-		"sodium": "~0.3.3",
+		"minecraft": "1.18.x",
+		"sodium": "~0.4.0",
 		"fabric-renderer-api-v1": ">=0.3.0"
 	}
 }


### PR DESCRIPTION
Change with Fabric API Changes, may a bit buggy in modImplementation line in build.gradle.

Currently sodium 0.4.0 aka 0.3.3 for 1.18, so no Fabric Rendering API on there.
and sodium 0.4-experiments branch will be 0.5.