### PR TITLE
Fix Indium not rendering replaced models

### DIFF
--- a/src/main/java/link/infra/indium/mixin/renderer/MixinItemRenderer.java
+++ b/src/main/java/link/infra/indium/mixin/renderer/MixinItemRenderer.java
@@ -51,10 +51,11 @@ public abstract class MixinItemRenderer implements AccessItemRenderer {
 	@Shadow
 	protected abstract void renderBakedItemModel(BakedModel model, ItemStack stack, int light, int overlay, MatrixStack matrixStack, VertexConsumer buffer);
 
-	@Inject(at = @At("HEAD"), method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation$Mode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", cancellable = true)
+	@Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/model/BakedModel;isBuiltin()Z"), method = "renderItem(Lnet/minecraft/item/ItemStack;Lnet/minecraft/client/render/model/json/ModelTransformation$Mode;ZLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;IILnet/minecraft/client/render/model/BakedModel;)V", cancellable = true)
 	public void hook_renderItem(ItemStack stack, ModelTransformation.Mode transformMode, boolean invert, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int light, int overlay, BakedModel model, CallbackInfo ci) {
-		if (!stack.isEmpty() && !((FabricBakedModel) model).isVanillaAdapter()) {
+		if (!((FabricBakedModel) model).isVanillaAdapter()) {
 			fabric_contexts.get().renderModel(stack, transformMode, invert, matrixStack, vertexConsumerProvider, light, overlay, model, indium_vanillaHandler);
+			matrixStack.pop();
 			ci.cancel();
 		}
 	}

--- a/src/main/java/link/infra/indium/mixin/sodium/MixinBlockRenderer.java
+++ b/src/main/java/link/infra/indium/mixin/sodium/MixinBlockRenderer.java
@@ -9,12 +9,12 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(BlockRenderer.class)
 public class MixinBlockRenderer implements AccessBlockRenderer {
-    @Shadow
-    @Final
-    private BlockOcclusionCache occlusionCache;
+	@Shadow
+	@Final
+	private BlockOcclusionCache occlusionCache;
 
-    @Override
-    public BlockOcclusionCache indium$getBlockOcclusionCache() {
-        return this.occlusionCache;
-    }
+	@Override
+	public BlockOcclusionCache indium$getBlockOcclusionCache() {
+		return this.occlusionCache;
+	}
 }

--- a/src/main/java/link/infra/indium/other/AccessBlockRenderer.java
+++ b/src/main/java/link/infra/indium/other/AccessBlockRenderer.java
@@ -3,5 +3,5 @@ package link.infra.indium.other;
 import me.jellysquid.mods.sodium.client.render.occlusion.BlockOcclusionCache;
 
 public interface AccessBlockRenderer {
-    BlockOcclusionCache indium$getBlockOcclusionCache();
+	BlockOcclusionCache indium$getBlockOcclusionCache();
 }

--- a/src/main/java/link/infra/indium/renderer/render/ItemRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/ItemRenderContext.java
@@ -16,6 +16,10 @@
 
 package link.infra.indium.renderer.render;
 
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
 import link.infra.indium.renderer.IndiumRenderer;
 import link.infra.indium.renderer.RenderMaterialImpl;
 import link.infra.indium.renderer.helper.ColorHelper;
@@ -30,11 +34,15 @@ import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.color.item.ItemColors;
-import net.minecraft.client.render.*;
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.RenderLayer;
+import net.minecraft.client.render.RenderLayers;
+import net.minecraft.client.render.TexturedRenderLayers;
+import net.minecraft.client.render.VertexConsumer;
+import net.minecraft.client.render.VertexConsumerProvider;
 import net.minecraft.client.render.item.ItemRenderer;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedQuad;
-import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.render.model.json.ModelTransformation.Mode;
 import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.item.BlockItem;
@@ -43,11 +51,6 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3f;
 import net.minecraft.util.math.random.Random;
-
-import java.util.List;
-
-import java.util.function.Consumer;
-import java.util.function.Supplier;
 
 /**
  * The render context used for item rendering.
@@ -102,15 +105,10 @@ public class ItemRenderContext extends MatrixRenderContext {
 		this.vanillaHandler = vanillaHandler;
 		computeOutputInfo();
 
-		matrixStack.push();
-		model.getTransformation().getTransformation(transformMode).apply(invert, matrixStack);
-		matrixStack.translate(-0.5D, -0.5D, -0.5D);
 		matrix = matrixStack.peek().getPositionMatrix();
 		normalMatrix = matrixStack.peek().getNormalMatrix();
 
 		((FabricBakedModel) model).emitItemQuads(itemStack, randomSupplier, this);
-
-		matrixStack.pop();
 
 		this.itemStack = null;
 		this.matrixStack = null;


### PR DESCRIPTION
This is a direct port of the fix for Indigo, FabricMC/fabric#2336.
As with the Indigo fix, this one should be backported to 1.18.2 as well.