### PR TITLE
Fix and Improve 0.5 Port

### DIFF
--- a/src/main/java/link/infra/indium/renderer/helper/GeometryHelper.java
+++ b/src/main/java/link/infra/indium/renderer/helper/GeometryHelper.java
@@ -20,12 +20,14 @@ import static net.minecraft.util.math.MathHelper.approximatelyEquals;
 
 import org.joml.Vector3f;
 
+import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
+import me.jellysquid.mods.sodium.client.util.DirectionUtil;
+import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Direction.Axis;
 import net.minecraft.util.math.Direction.AxisDirection;
-
-import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
+import net.minecraft.util.math.MathHelper;
 
 /**
  * Static routines of general utility for renderer implementations.
@@ -195,6 +197,33 @@ public abstract class GeometryHelper {
 			// handle WTF case
 			return Direction.UP;
 		}
+	}
+
+	// Copied from ModelQuadUtil.findNormalFace to prevent unnecessary allocation
+	public static ModelQuadFacing normalFace(QuadView quad) {
+		final Vector3f normal = quad.faceNormal();
+
+		if (!normal.isFinite()) {
+			return ModelQuadFacing.UNASSIGNED;
+		}
+
+		float maxDot = 0;
+		Direction closestFace = null;
+
+		for (Direction face : DirectionUtil.ALL_DIRECTIONS) {
+			float dot = normal.dot(face.getUnitVector());
+
+			if (dot > maxDot) {
+				maxDot = dot;
+				closestFace = face;
+			}
+		}
+
+		if (closestFace != null && MathHelper.approximatelyEquals(maxDot, 1.0f)) {
+			return ModelQuadFacing.fromDirection(closestFace);
+		}
+
+		return ModelQuadFacing.UNASSIGNED;
 	}
 
 	/**

--- a/src/main/java/link/infra/indium/renderer/mesh/QuadViewImpl.java
+++ b/src/main/java/link/infra/indium/renderer/mesh/QuadViewImpl.java
@@ -172,6 +172,11 @@ public class QuadViewImpl implements QuadView {
 		return normalFlags() != 0;
 	}
 
+	/** True if all vertex normals have been set. */
+	public boolean hasAllVertexNormals() {
+		return (normalFlags() & 0b1111) == 0b1111;
+	}
+
 	protected final int normalIndex(int vertexIndex) {
 		return baseIndex + vertexIndex * VERTEX_STRIDE + VERTEX_NORMAL;
 	}

--- a/src/main/java/link/infra/indium/renderer/mesh/QuadViewImpl.java
+++ b/src/main/java/link/infra/indium/renderer/mesh/QuadViewImpl.java
@@ -41,6 +41,7 @@ import link.infra.indium.renderer.helper.ColorHelper;
 import link.infra.indium.renderer.helper.GeometryHelper;
 import link.infra.indium.renderer.helper.NormalHelper;
 import link.infra.indium.renderer.material.RenderMaterialImpl;
+import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadView;
 import net.minecraft.util.math.Direction;
 
@@ -51,7 +52,7 @@ import net.minecraft.util.math.Direction;
 public class QuadViewImpl implements QuadView {
 	@Nullable
 	protected Direction nominalFace;
-	/** True when face normal, light face, or geometry flags may not match geometry. */
+	/** True when face normal, light face, normal face, or geometry flags may not match geometry. */
 	protected boolean isGeometryInvalid = true;
 	protected final Vector3f faceNormal = new Vector3f();
 
@@ -80,6 +81,9 @@ public class QuadViewImpl implements QuadView {
 
 			// depends on face normal
 			data[baseIndex + HEADER_BITS] = EncodingFormat.lightFace(data[baseIndex + HEADER_BITS], GeometryHelper.lightFace(this));
+
+			// depends on face normal
+			data[baseIndex + HEADER_BITS] = EncodingFormat.normalFace(data[baseIndex + HEADER_BITS], GeometryHelper.normalFace(this));
 
 			// depends on light face
 			data[baseIndex + HEADER_BITS] = EncodingFormat.geometryFlags(data[baseIndex + HEADER_BITS], GeometryHelper.computeShapeFlags(this));
@@ -223,6 +227,11 @@ public class QuadViewImpl implements QuadView {
 	public final Direction lightFace() {
 		computeGeometry();
 		return EncodingFormat.lightFace(data[baseIndex + HEADER_BITS]);
+	}
+
+	public final ModelQuadFacing normalFace() {
+		computeGeometry();
+		return EncodingFormat.normalFace(data[baseIndex + HEADER_BITS]);
 	}
 
 	@Override

--- a/src/main/java/link/infra/indium/renderer/render/AbstractBlockRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/AbstractBlockRenderContext.java
@@ -21,15 +21,19 @@ import static link.infra.indium.renderer.helper.GeometryHelper.LIGHT_FACE_FLAG;
 
 import java.util.List;
 
-import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.DefaultMaterials;
-import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import org.jetbrains.annotations.Nullable;
+import org.joml.Vector3f;
 
+import link.infra.indium.Indium;
 import link.infra.indium.renderer.IndiumRenderer;
 import link.infra.indium.renderer.aocalc.AoCalculator;
+import link.infra.indium.renderer.aocalc.AoConfig;
 import link.infra.indium.renderer.helper.ColorHelper;
 import link.infra.indium.renderer.mesh.EncodingFormat;
 import link.infra.indium.renderer.mesh.MutableQuadViewImpl;
+import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
+import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.DefaultMaterials;
+import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import net.fabricmc.fabric.api.renderer.v1.material.RenderMaterial;
 import net.fabricmc.fabric.api.renderer.v1.mesh.QuadEmitter;
 import net.fabricmc.fabric.api.renderer.v1.model.ModelHelper;
@@ -42,6 +46,7 @@ import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.BakedQuad;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
+import net.minecraft.world.BlockRenderView;
 
 /**
  * Subclasses must set the {@link #blockInfo} and {@link #aoCalc} fields in their constructor.
@@ -64,7 +69,7 @@ public abstract class AbstractBlockRenderContext extends AbstractRenderContext {
 
 	private final BakedModelConsumerImpl vanillaModelConsumer = new BakedModelConsumerImpl();
 
-	private final BlockPos.Mutable lightPos = new BlockPos.Mutable();
+	protected abstract LightDataAccess getLightCache();
 
 	protected abstract void bufferQuad(MutableQuadViewImpl quad, Material material);
 
@@ -129,14 +134,14 @@ public abstract class AbstractBlockRenderContext extends AbstractRenderContext {
 				}
 			}
 		} else {
-			shadeFlatQuad(quad);
+			shadeFlatQuad(quad, isVanilla);
 
 			if (emissive) {
 				for (int i = 0; i < 4; i++) {
 					quad.lightmap(i, LightmapTextureManager.MAX_LIGHT_COORDINATE);
 				}
 			} else {
-				final int brightness = flatBrightness(quad, blockInfo.blockState, blockInfo.blockPos);
+				final int brightness = flatBrightness(quad);
 
 				for (int i = 0; i < 4; i++) {
 					quad.lightmap(i, ColorHelper.maxBrightness(quad.lightmap(i), brightness));
@@ -149,28 +154,55 @@ public abstract class AbstractBlockRenderContext extends AbstractRenderContext {
 	 * Starting in 1.16 flat shading uses dimension-specific diffuse factors that can be < 1.0
 	 * even for un-shaded quads. These are also applied with AO shading but that is done in AO calculator.
 	 */
-	private void shadeFlatQuad(MutableQuadViewImpl quad) {
-		if (quad.hasVertexNormals()) {
-			// Quads that have vertex normals need to be shaded using interpolation - vanilla can't
-			// handle them. Generally only applies to modded models.
-			final float faceShade = blockInfo.blockView.getBrightness(quad.lightFace(), quad.hasShade());
+	private void shadeFlatQuad(MutableQuadViewImpl quad, boolean isVanilla) {
+		final boolean hasShade = quad.hasShade();
 
-			for (int i = 0; i < 4; i++) {
-				quad.color(i, ColorHelper.multiplyRGB(quad.color(i), vertexShade(quad, i, faceShade)));
+		// Check the AO mode to match how shade is applied during smooth lighting
+		if ((Indium.AMBIENT_OCCLUSION_MODE == AoConfig.HYBRID && !isVanilla) || Indium.AMBIENT_OCCLUSION_MODE == AoConfig.ENHANCED) {
+			if (quad.hasAllVertexNormals()) {
+				for (int i = 0; i < 4; i++) {
+					float shade = normalShade(quad.normalX(i), quad.normalY(i), quad.normalZ(i), hasShade);
+					quad.color(i, ColorHelper.multiplyRGB(quad.color(i), shade));
+				}
+			} else {
+				final float faceShade;
+
+				if ((quad.geometryFlags() & AXIS_ALIGNED_FLAG) != 0) {
+					faceShade = blockInfo.blockView.getBrightness(quad.lightFace(), hasShade);
+				} else {
+					Vector3f faceNormal = quad.faceNormal();
+					faceShade = normalShade(faceNormal.x, faceNormal.y, faceNormal.z, hasShade);
+				}
+
+				if (quad.hasVertexNormals()) {
+					for (int i = 0; i < 4; i++) {
+						float shade;
+
+						if (quad.hasNormal(i)) {
+							shade = normalShade(quad.normalX(i), quad.normalY(i), quad.normalZ(i), hasShade);
+						} else {
+							shade = faceShade;
+						}
+
+						quad.color(i, ColorHelper.multiplyRGB(quad.color(i), shade));
+					}
+				} else {
+					if (faceShade != 1.0f) {
+						for (int i = 0; i < 4; i++) {
+							quad.color(i, ColorHelper.multiplyRGB(quad.color(i), faceShade));
+						}
+					}
+				}
 			}
 		} else {
-			final float diffuseShade = blockInfo.blockView.getBrightness(quad.lightFace(), quad.hasShade());
+			final float faceShade = blockInfo.blockView.getBrightness(quad.lightFace(), hasShade);
 
-			if (diffuseShade != 1.0f) {
+			if (faceShade != 1.0f) {
 				for (int i = 0; i < 4; i++) {
-					quad.color(i, ColorHelper.multiplyRGB(quad.color(i), diffuseShade));
+					quad.color(i, ColorHelper.multiplyRGB(quad.color(i), faceShade));
 				}
 			}
 		}
-	}
-
-	private float vertexShade(MutableQuadViewImpl quad, int vertexIndex, float faceShade) {
-		return quad.hasNormal(vertexIndex) ? normalShade(quad.normalX(vertexIndex), quad.normalY(vertexIndex), quad.normalZ(vertexIndex), quad.hasShade()) : faceShade;
 	}
 
 	/**
@@ -213,25 +245,46 @@ public abstract class AbstractBlockRenderContext extends AbstractRenderContext {
 	 * Handles geometry-based check for using self brightness or neighbor brightness.
 	 * That logic only applies in flat lighting.
 	 */
-	private int flatBrightness(MutableQuadViewImpl quad, BlockState blockState, BlockPos pos) {
-		lightPos.set(pos);
+	private int flatBrightness(MutableQuadViewImpl quad) {
+		LightDataAccess lightCache = getLightCache();
+		BlockPos pos = blockInfo.blockPos;
+		Direction cullFace = quad.cullFace();
 
-		// To mirror Vanilla's behavior, if the face has a cull-face, always sample the light value
-		// offset in that direction. See net.minecraft.client.render.block.BlockModelRenderer.renderQuadsFlat
-		// for reference.
-		if (quad.cullFace() != null) {
-			lightPos.move(quad.cullFace());
+		// To match vanilla behavior, use the cull face if it exists/is available
+		if (cullFace != null) {
+			return getOffsetLightmap(lightCache, pos, cullFace);
 		} else {
 			final int flags = quad.geometryFlags();
 
-			if ((flags & LIGHT_FACE_FLAG) != 0 || ((flags & AXIS_ALIGNED_FLAG) != 0 && blockState.isFullCube(blockInfo.blockView, pos))) {
-				lightPos.move(quad.lightFace());
+			// If the face is aligned, use the light data above it
+			// To match vanilla behavior, also treat the face as aligned if it is parallel and the block state is a full cube
+			if ((flags & LIGHT_FACE_FLAG) != 0 || ((flags & AXIS_ALIGNED_FLAG) != 0 && LightDataAccess.unpackFC(lightCache.get(pos)))) {
+				return getOffsetLightmap(lightCache, pos, quad.lightFace());
+			} else {
+				return LightDataAccess.getEmissiveLightmap(lightCache.get(pos));
 			}
 		}
-
-		// Unfortunately cannot use brightness cache here unless we implement one specifically for flat lighting. See #329
-		return WorldRenderer.getLightmapCoordinates(blockInfo.blockView, blockState, lightPos);
 	}
+
+	/**
+     * When vanilla computes an offset lightmap with flat lighting, it passes the original BlockState but the
+     * offset BlockPos to {@link WorldRenderer#getLightmapCoordinates(BlockRenderView, BlockState, BlockPos)}.
+     * This does not make much sense but fixes certain issues, primarily dark quads on light-emitting blocks
+     * behind tinted glass. {@link LightDataAccess} cannot efficiently store lightmaps computed with
+     * inconsistent values so this method exists to mirror vanilla behavior as closely as possible.
+     */
+    private static int getOffsetLightmap(LightDataAccess lightCache, BlockPos pos, Direction face) {
+        int word = lightCache.get(pos);
+
+        // Check emissivity of the origin state
+        if (LightDataAccess.unpackEM(word)) {
+            return LightmapTextureManager.MAX_LIGHT_COORDINATE;
+        }
+
+        // Use world light values from the offset pos, but luminance from the origin pos
+        int adjWord = lightCache.get(pos, face);
+        return LightmapTextureManager.pack(Math.max(LightDataAccess.unpackBL(adjWord), LightDataAccess.unpackLU(word)), LightDataAccess.unpackSL(adjWord));
+    }
 
 	/**
 	 * Consumer for vanilla baked models. Generally intended to give visual results matching a vanilla render,

--- a/src/main/java/link/infra/indium/renderer/render/AbstractBlockRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/AbstractBlockRenderContext.java
@@ -267,24 +267,24 @@ public abstract class AbstractBlockRenderContext extends AbstractRenderContext {
 	}
 
 	/**
-     * When vanilla computes an offset lightmap with flat lighting, it passes the original BlockState but the
-     * offset BlockPos to {@link WorldRenderer#getLightmapCoordinates(BlockRenderView, BlockState, BlockPos)}.
-     * This does not make much sense but fixes certain issues, primarily dark quads on light-emitting blocks
-     * behind tinted glass. {@link LightDataAccess} cannot efficiently store lightmaps computed with
-     * inconsistent values so this method exists to mirror vanilla behavior as closely as possible.
-     */
-    private static int getOffsetLightmap(LightDataAccess lightCache, BlockPos pos, Direction face) {
-        int word = lightCache.get(pos);
+	 * When vanilla computes an offset lightmap with flat lighting, it passes the original BlockState but the
+	 * offset BlockPos to {@link WorldRenderer#getLightmapCoordinates(BlockRenderView, BlockState, BlockPos)}.
+	 * This does not make much sense but fixes certain issues, primarily dark quads on light-emitting blocks
+	 * behind tinted glass. {@link LightDataAccess} cannot efficiently store lightmaps computed with
+	 * inconsistent values so this method exists to mirror vanilla behavior as closely as possible.
+	 */
+	private static int getOffsetLightmap(LightDataAccess lightCache, BlockPos pos, Direction face) {
+		int word = lightCache.get(pos);
 
-        // Check emissivity of the origin state
-        if (LightDataAccess.unpackEM(word)) {
-            return LightmapTextureManager.MAX_LIGHT_COORDINATE;
-        }
+		// Check emissivity of the origin state
+		if (LightDataAccess.unpackEM(word)) {
+			return LightmapTextureManager.MAX_LIGHT_COORDINATE;
+		}
 
-        // Use world light values from the offset pos, but luminance from the origin pos
-        int adjWord = lightCache.get(pos, face);
-        return LightmapTextureManager.pack(Math.max(LightDataAccess.unpackBL(adjWord), LightDataAccess.unpackLU(word)), LightDataAccess.unpackSL(adjWord));
-    }
+		// Use world light values from the offset pos, but luminance from the origin pos
+		int adjWord = lightCache.get(pos, face);
+		return LightmapTextureManager.pack(Math.max(LightDataAccess.unpackBL(adjWord), LightDataAccess.unpackLU(word)), LightDataAccess.unpackSL(adjWord));
+	}
 
 	/**
 	 * Consumer for vanilla baked models. Generally intended to give visual results matching a vanilla render,

--- a/src/main/java/link/infra/indium/renderer/render/NonTerrainBlockRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/NonTerrainBlockRenderContext.java
@@ -18,6 +18,7 @@ package link.infra.indium.renderer.render;
 
 import link.infra.indium.renderer.aocalc.AoCalculator;
 import link.infra.indium.renderer.mesh.MutableQuadViewImpl;
+import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.VertexConsumer;
@@ -37,6 +38,11 @@ public class NonTerrainBlockRenderContext extends AbstractBlockRenderContext {
 	public NonTerrainBlockRenderContext() {
 		blockInfo = new BlockRenderInfo();
 		aoCalc = new AoCalculator(blockInfo, lightCache);
+	}
+
+	@Override
+	protected LightDataAccess getLightCache() {
+		return lightCache;
 	}
 
 	@Override

--- a/src/main/java/link/infra/indium/renderer/render/TerrainRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/TerrainRenderContext.java
@@ -1,11 +1,14 @@
 package link.infra.indium.renderer.render;
 
+import org.joml.Vector3fc;
+
 import link.infra.indium.mixin.sodium.AccessBlockRenderer;
 import link.infra.indium.other.SpriteFinderCache;
 import link.infra.indium.renderer.accessor.AccessBlockRenderCache;
 import link.infra.indium.renderer.aocalc.AoCalculator;
 import link.infra.indium.renderer.mesh.MutableQuadViewImpl;
 import me.jellysquid.mods.sodium.client.model.light.data.ArrayLightDataCache;
+import me.jellysquid.mods.sodium.client.model.light.data.LightDataAccess;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadFacing;
 import me.jellysquid.mods.sodium.client.model.quad.properties.ModelQuadOrientation;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.ChunkBuildBuffers;
@@ -25,9 +28,10 @@ import net.minecraft.util.crash.CrashReportSection;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.random.LocalRandom;
-import org.joml.Vector3fc;
 
 public class TerrainRenderContext extends AbstractBlockRenderContext {
+	private final ArrayLightDataCache lightCache;
+
 	private final ChunkVertexEncoder.Vertex[] vertices = ChunkVertexEncoder.Vertex.uninitializedQuad();
 
 	private ChunkBuildBuffers buffers;
@@ -38,7 +42,7 @@ public class TerrainRenderContext extends AbstractBlockRenderContext {
 	public TerrainRenderContext(BlockRenderCache renderCache) {
 		WorldSlice worldSlice = renderCache.getWorldSlice();
 		BlockOcclusionCache blockOcclusionCache = ((AccessBlockRenderer) renderCache.getBlockRenderer()).indium$occlusionCache();
-		ArrayLightDataCache lightCache = ((AccessBlockRenderCache) renderCache).indium$getLightDataCache();
+		lightCache = ((AccessBlockRenderCache) renderCache).indium$getLightDataCache();
 
 		blockInfo = new TerrainBlockRenderInfo(blockOcclusionCache);
 		blockInfo.random = new LocalRandom(42L);
@@ -48,6 +52,11 @@ public class TerrainRenderContext extends AbstractBlockRenderContext {
 
 	public static TerrainRenderContext get(ChunkBuildContext buildContext) {
 		return ((AccessBlockRenderCache) buildContext.cache).indium$getTerrainRenderContext();
+	}
+
+	@Override
+	protected LightDataAccess getLightCache() {
+		return lightCache;
 	}
 
 	@Override
@@ -99,8 +108,8 @@ public class TerrainRenderContext extends AbstractBlockRenderContext {
 			// Assumes aoCalc.ao / aoCalc.light holds the correct values for the current quad.
 			quad.orientation(ModelQuadOrientation.orientByBrightness(aoCalc.ao, aoCalc.light));
 		} else {
-			// When using flat lighting, Sodium makes all quads use the flipped orientation.
-			quad.orientation(ModelQuadOrientation.FLIP);
+			// When using flat lighting, all quads use the normal orientation.
+			quad.orientation(ModelQuadOrientation.NORMAL);
 		}
 	}
 

--- a/src/main/java/link/infra/indium/renderer/render/TerrainRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/TerrainRenderContext.java
@@ -25,7 +25,6 @@ import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.crash.CrashException;
 import net.minecraft.util.crash.CrashReport;
 import net.minecraft.util.crash.CrashReportSection;
-import net.minecraft.util.math.Direction;
 import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.random.LocalRandom;
 
@@ -61,11 +60,6 @@ public class TerrainRenderContext extends AbstractBlockRenderContext {
 
 	@Override
 	protected void bufferQuad(MutableQuadViewImpl quad, Material material) {
-		ChunkModelBuilder builder = buffers.get(material);
-
-		Direction cullFace = quad.cullFace();
-		var vertexBuffer = builder.getVertexBuffer(cullFace != null ? ModelQuadFacing.fromDirection(cullFace) : ModelQuadFacing.UNASSIGNED);
-
 		Vector3fc origin = this.origin;
 		Vec3d modelOffset = this.modelOffset;
 
@@ -89,6 +83,9 @@ public class TerrainRenderContext extends AbstractBlockRenderContext {
 			out.light = quad.lightmap(srcIndex);
 		}
 
+		ChunkModelBuilder builder = buffers.get(material);
+		ModelQuadFacing normalFace = quad.normalFace();
+		var vertexBuffer = builder.getVertexBuffer(normalFace);
 		vertexBuffer.push(vertices, material);
 
 		Sprite sprite = quad.cachedSprite();


### PR DESCRIPTION
- Fix `AoCalculator` using the opaque property incorrectly
- Fix `AoCalculator` not checking emissivity
- Change `AoCalculator` `lightCenter` calculation to match Sodium
- Use `LightDataAccess` to calculate flat lighting as well
- Fix flat lighting quad orientation
- Use normal face instead of cull face to decide vertex buffer
- Port new Indigo changes (FabricMC/fabric#3208)