### PR TITLE
Update to Sodium 0.5.4/0.5.5 and Minecraft 1.20.3/1.20.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,18 +2,18 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.1
-yarn_mappings=1.20.1+build.8
-loader_version=0.14.21
+minecraft_version=1.20.3
+yarn_mappings=1.20.3+build.1
+loader_version=0.15.0
 # Mod Properties
 mod_version=1.0.27
 maven_group=link.infra
 archives_base_name=indium
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.89.0+1.20.1
-sodium_version=0.5.3
-sodium_minecraft_version=1.20.1
+fabric_version=0.91.1+1.20.3
+sodium_version=0.5.4
+sodium_minecraft_version=1.20.3
 # Publishing metadata
 curseforge_id=459496
 source_url=https://github.com/comp500/Indium/

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ archives_base_name=indium
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
 fabric_version=0.91.1+1.20.3
-sodium_version=0.5.4
+sodium_version=0.5.5
 sodium_minecraft_version=1.20.3
 # Publishing metadata
 curseforge_id=459496

--- a/src/main/java/link/infra/indium/renderer/render/TerrainRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/TerrainRenderContext.java
@@ -1,7 +1,6 @@
 package link.infra.indium.renderer.render;
 
 import org.joml.Vector3fc;
-
 import link.infra.indium.mixin.sodium.AccessBlockRenderer;
 import link.infra.indium.other.SpriteFinderCache;
 import link.infra.indium.renderer.accessor.AccessBlockRenderCache;
@@ -18,7 +17,9 @@ import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockOcclu
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderCache;
 import me.jellysquid.mods.sodium.client.render.chunk.compile.pipeline.BlockRenderContext;
 import me.jellysquid.mods.sodium.client.render.chunk.terrain.material.Material;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.builder.ChunkMeshBufferBuilder;
 import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder;
+import me.jellysquid.mods.sodium.client.render.chunk.vertex.format.ChunkVertexEncoder.Vertex;
 import me.jellysquid.mods.sodium.client.world.WorldSlice;
 import net.caffeinemc.mods.sodium.api.util.ColorARGB;
 import net.minecraft.client.texture.Sprite;

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,8 +28,8 @@
 	],
 	"depends": {
 		"fabricloader": ">=0.8.0",
-		"minecraft": "~1.20.1",
-		"sodium": "0.5.3",
+		"minecraft": "1.20.x",
+		"sodium": ">=0.5.3",
 		"fabric-renderer-api-v1": ">=3.2.0",
 		"fabric-resource-loader-v0": ">=0.4.0"
 	}


### PR DESCRIPTION
This is my first time porting this mod, so I might be unable to fix it if you guys encounter any issues.

EDIT: I saw that 1.20.4 has been released. This should still work on that version.