### PR TITLE
Fix non-terrain model offset

### DIFF
--- a/src/main/java/link/infra/indium/renderer/render/NonTerrainBlockRenderContext.java
+++ b/src/main/java/link/infra/indium/renderer/render/NonTerrainBlockRenderContext.java
@@ -24,7 +24,11 @@ import net.minecraft.block.BlockState;
 import net.minecraft.client.render.VertexConsumer;
 import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.util.crash.CrashException;
+import net.minecraft.util.crash.CrashReport;
+import net.minecraft.util.crash.CrashReportSection;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Vec3d;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.BlockRenderView;
 
@@ -51,24 +55,34 @@ public class NonTerrainBlockRenderContext extends AbstractBlockRenderContext {
 	}
 
 	public void render(BlockRenderView blockView, BakedModel model, BlockState state, BlockPos pos, MatrixStack matrixStack, VertexConsumer buffer, boolean cull, Random random, long seed, int overlay) {
-		this.vertexConsumer = buffer;
-		this.matrix = matrixStack.peek().getPositionMatrix();
-		this.normalMatrix = matrixStack.peek().getNormalMatrix();
-		this.overlay = overlay;
+		try {	
+			Vec3d offset = state.getModelOffset(blockView, pos);
+			matrixStack.translate(offset.x, offset.y, offset.z);
 
-		blockInfo.random = random;
+			this.vertexConsumer = buffer;
+			this.matrix = matrixStack.peek().getPositionMatrix();
+			this.normalMatrix = matrixStack.peek().getNormalMatrix();
+			this.overlay = overlay;
 
-		aoCalc.clear();
-		lightCache.reset(pos, blockView);
-		blockInfo.prepareForWorld(blockView, cull);
-		blockInfo.prepareForBlock(state, pos, seed, model.useAmbientOcclusion());
+			blockInfo.random = random;
 
-		model.emitBlockQuads(blockView, state, pos, blockInfo.randomSupplier, this);
+			aoCalc.clear();
+			lightCache.reset(pos, blockView);
+			blockInfo.prepareForWorld(blockView, cull);
+			blockInfo.prepareForBlock(state, pos, seed, model.useAmbientOcclusion());
 
-		// blockInfo is thread-local, not cleaned up when leaving world (and could be called for arbitrary BlockRenderViews)
-		blockInfo.release();
-		lightCache.release();
-		blockInfo.random = null;
-		this.vertexConsumer = null;
+			model.emitBlockQuads(blockView, state, pos, blockInfo.randomSupplier, this);
+		} catch (Throwable throwable) {
+			CrashReport crashReport = CrashReport.create(throwable, "Tessellating block model - Indium Renderer");
+			CrashReportSection crashReportSection = crashReport.addElement("Block model being tessellated");
+			CrashReportSection.addBlockInfo(crashReportSection, blockView, pos, state);
+			throw new CrashException(crashReport);
+		} finally {
+			// blockInfo is thread-local, not cleaned up when leaving world (and could be called for arbitrary BlockRenderViews)
+			blockInfo.release();
+			lightCache.release();
+			blockInfo.random = null;
+			this.vertexConsumer = null;
+		}
 	}
 }


### PR DESCRIPTION
Port of FabricMC/fabric#3799, which fixes FabricMC/fabric#3798. Indium has the same bug. This fix should be backported and released for at least 1.20.1, 1.20.4, and 1.20.6.