### PR TITLE
Update to Sodium 0.5.9 for MC 1.20.6

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,18 +2,18 @@
 org.gradle.jvmargs=-Xmx1G
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.20.4
-yarn_mappings=1.20.4+build.3
-loader_version=0.15.3
+minecraft_version=1.20.6
+yarn_mappings=1.20.6+build.3
+loader_version=0.15.11
 # Mod Properties
 mod_version=1.0.32
 maven_group=link.infra
 archives_base_name=indium
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.91.3+1.20.4
+fabric_version=0.100.0+1.20.6
 sodium_version=0.5.9
-sodium_minecraft_version=1.20.4
+sodium_minecraft_version=1.20.6
 # Publishing metadata
 curseforge_id=459496
 source_url=https://github.com/comp500/Indium/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Successful build for MC 1.20.6, sodium update 0.5.9

Used gradle-8.8 and Java 21.

[indium-1.0.32-dev.9e72717+mc1.20.6-dirty-sources.zip](https://github.com/user-attachments/files/15830350/indium-1.0.32-dev.9e72717%2Bmc1.20.6-dirty-sources.zip)
